### PR TITLE
Analyze collision issues

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -22,9 +22,6 @@ const game = {
     player: new Player(75, 100)
 };
 
-
-
-
 let img = new Image();
 img.src = 'assets/tilescat.png';
 img.onload = function () {
@@ -53,31 +50,15 @@ img.onload = function () {
     levelsManager.addLevel(tileEngine);
 };
 
-
-
-
-
 initKeys(); // initialize the keyboard input
 let loop = GameLoop({  // create the main game loop
-    update: function () { // update the game state
+    update: function (dt) { // update the game state
 
-        let level = levelsManager.getLevel(game.currentLevel);
-        if (level) {
-            let playerPosition = game.player.getPosition();
+        const level = levelsManager.getLevel(game.currentLevel);
+        
+        if (!level) return
 
-            if (playerPosition.x > (canvas.width / 2) - 16) {
-
-                level.sx++;
-
-            } else {
-                game.player.setPosition(playerPosition.x + 1, playerPosition.y);
-            }
-            let collides = levelsManager.getColliderPosition(game.currentLevel, game.player.sprite);
-            game.player.update(game.currentLevel); // update the player
-        }
-
-
-
+        game.player.update(dt, game.currentLevel); // update the player
     },
     render: function () { // render the game state
         let level = levelsManager.getLevel(game.currentLevel);

--- a/js/levelData.js
+++ b/js/levelData.js
@@ -34,7 +34,7 @@ export class LevelsManager {
         
         return level.tileAtLayer('ground', data);
     }
-    getColliderPosition(levelIndex,sprite){
+    layerCollidesWith(levelIndex,sprite){
         const level = this.getLevel(levelIndex);
         if (!level) {
             //throw new Error("Level not found");

--- a/js/player.js
+++ b/js/player.js
@@ -1,21 +1,21 @@
 import { Sprite, keyPressed } from "./kontra.min.mjs";
 import { levelsManager, LevelsManager } from "./levelData.js";
 
-
-const INITIAL_JUMP_FORCE = 16;
-const GRAVITY = 2;
+const INITIAL_JUMP_FORCE = 4;
+const GRAVITY = 3;
+const MAX_X_VELOCITY = 0.5;
 export class Player {
   sprite;
   isJumping = false;
+  firstGround = false;
   constructor(x, y) {
-
     this.sprite = Sprite({
       x: x,
       y: y,
-      color: 'blue',
+      color: "blue",
       width: 16,
       height: 16,
-      anchor: {x: 1, y: 2},
+      anchor: { x: 1, y: 2 },
     });
   }
 
@@ -28,29 +28,34 @@ export class Player {
     this.sprite.y = y;
   }
 
-  update(levelIndex) {
+  // Using dt (delta time) in physics calculations because of colliding issues
+  update(dt, levelIndex) {
+    const isColliding = levelsManager.layerCollidesWith(levelIndex, this.sprite);
+    const tileEngine = levelsManager.getLevel(levelIndex);
 
-    this.sprite.dy += GRAVITY;
-    const collides = levelsManager.getColliderPosition(levelIndex,this.sprite);
-     // Ground collision
-    if (collides) {
+    // Move camera along with the player
+    tileEngine.sx += this.sprite.dx;
 
-        this.sprite.dy = 0;
-     
+    // Ground collision
+    if (isColliding) {
+      this.sprite.dy = 0;
+
       this.isJumping = false;
-     
+
+      // Move the player when is grounded
+      this.horizontalMovement(dt);
+    } else {
+      this.sprite.dy += GRAVITY * dt;
     }
 
     // Jump when space is pressed and not already jumping
-    if (keyPressed('space') && !this.isJumping) {
-      this.sprite.dy = -INITIAL_JUMP_FORCE;
+    if (keyPressed("space") && !this.isJumping) {
+      this.sprite.dy -= INITIAL_JUMP_FORCE;
+
       this.isJumping = true;
     }
 
-    
-   
     // Update position
-    this.sprite.y += this.sprite.dy;
     this.sprite.update();
   }
 
@@ -58,4 +63,8 @@ export class Player {
     this.sprite.render();
   }
 
+  horizontalMovement(dt) {
+    this.sprite.dx += 1 * dt;
+    if (this.sprite.dx >= MAX_X_VELOCITY) this.sprite.dx = MAX_X_VELOCITY;
+  }
 }

--- a/js/player.js
+++ b/js/player.js
@@ -15,7 +15,6 @@ export class Player {
       color: "blue",
       width: 16,
       height: 16,
-      anchor: { x: 1, y: 2 },
     });
   }
 
@@ -30,7 +29,10 @@ export class Player {
 
   // Using dt (delta time) in physics calculations because of colliding issues
   update(dt, levelIndex) {
-    const isColliding = levelsManager.layerCollidesWith(levelIndex, this.sprite);
+    const isColliding = levelsManager.layerCollidesWith(
+      levelIndex,
+      this.sprite
+    );
     const tileEngine = levelsManager.getLevel(levelIndex);
 
     // Move camera along with the player


### PR DESCRIPTION
Parece ser que el problema de las colisiones tiene que ver con la velocidad a la que se mueve el sprite. Al engine no le da tiempo a calcular correctamente las colisiones y por eso traspasa los tiles hasta que consigue calcular la colisión. He usado `dt` (delta time) en la función `update` junto con la velocidad (la he editado un poco para que cuadre mejor) y parece que ahora falla menos (aunque si la velocidad sube, volverá a traspasar). Aunque en la documentación del engine dice que no hace falta usar `dt`, ahora parece que va mejor. Además, he añadido y cambiado algunas cosas para que el sprite se mueva cuando está en el suelo y la cámara se mueva junto al jugador a su misma velocidad.

[Información sobre GameLoop](https://straker.github.io/kontra/api/gameLoop)